### PR TITLE
Fix import of pymeshlab and diffusers

### DIFF
--- a/mesh_utils.py
+++ b/mesh_utils.py
@@ -1,6 +1,13 @@
 import numpy as np
 import pymeshlab as pml
 
+if not hasattr(pml, "Percentage"):
+    # fix regression of pymeshlab
+    # https://github.com/cnr-isti-vclab/PyMeshLab/issues/347
+    print("Monkey patching pymeshlab")
+    pml.Percentage = pml.PercentageValue
+    pml.AbsoluteValue = pml.PureValue
+
 
 def poisson_mesh_reconstruction(points, normals=None):
     # points/normals: [N, 3] np.ndarray

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ dearpygui
 
 # for stable-diffusion
 huggingface_hub
-diffusers >= 0.9.0
+diffusers >= 0.9.0,<=0.21.4
 accelerate
 transformers
 


### PR DESCRIPTION
- fix: diffusers version must not be above 0.21.4
https://github.com/dreamgaussian/dreamgaussian/issues/80

- fix: regression in pymeshlab to have Percentage and AbsoluteValue back
https://github.com/cnr-isti-vclab/PyMeshLab/issues/347
